### PR TITLE
Add PaperHive widget iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This plugin changes the book page and the catalog view. The plugin contains lang
  * The cover at the book page is replaced by a bigger one. 
  * The book page can be added with a statistic image. The path to a folder containing the image needs to be specified in the plugin setting. The path can be a local folder (e.g. /public/stats/) or an external url (e.g. https://raw.githubusercontent.com/...). Currently only png images are displayed.
  * The vg wort pixel is included to the download buttons (pixel may be added with the vg wort plugin). 
+ * PaperHive widget on book page
  * Link to gitHub repo at book page.
  * Display reviews from the catalogEntryTab (can be added at the links tab). 
   

--- a/templates/langsci_monograph_full.tpl
+++ b/templates/langsci_monograph_full.tpl
@@ -320,6 +320,20 @@
 						{/if}
 					{/foreach}{* Publication formats loop *}
 				</div>
+
+				{* langsci: PaperHive widget *}
+				<div class="item langsci_paperhive">
+					<iframe
+						src="https://paperhive.org/widget/#type=langsci&id={$publishedMonograph->getId()}"
+						width="100%"
+						height="40px"
+						scrolling="no"
+						frameborder="0"
+						allowtransparency="true"
+						style="border:none;overflow:hidden;width:100%;"
+					></iframe>
+				</div>
+				{* end langsci *}
 				
 				{* langsci: view the code on github *}
 				<div class="item langsci_github">

--- a/templates/langsci_monograph_full.tpl
+++ b/templates/langsci_monograph_full.tpl
@@ -324,7 +324,7 @@
 				{* langsci: PaperHive widget *}
 				<div class="item langsci_paperhive">
 					<iframe
-						src="https://paperhive.org/widget/#type=langsci&id={$publishedMonograph->getId()}"
+						src="https://paperhive.org/widget/#type=langsci&id={$publishedMonograph->getId()}&restrictToLatest=true"
 						width="100%"
 						height="40px"
 						scrolling="no"


### PR DESCRIPTION
As discussed with Sebastian, I'm sending you a PR for the integration of the PaperHive widget on the LSP book pages. A few remarks:
* HTML is analogous to box *LaTeX source on GitHub*
* only one `iframe` element with the book id as a parameter 
* the widget is responsive, so in case your layout changes it will adapt
* no security issues since the `iframe` sandboxes its content (so PaperHive code can't run in the LSP context)
* the PaperHive widget is free software itself and available here: https://github.com/paperhive/paperhive-widget

Screenshot:
![screenshot from 2017-06-08 16-04-04](https://user-images.githubusercontent.com/1874116/26932828-fecfd81e-4c64-11e7-9c93-0adff74217c3.png)